### PR TITLE
ポイント付与ロジックの更新、キャンセル時のポイント取り消し実装

### DIFF
--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -5,14 +5,8 @@ permissions:
   pull-requests: write
 
 on:
-  workflow_dispatch:
-    inputs:
-      top_p:
-        description: 'top_p'
-        required: true
-      temperature:
-        description: 'temperature'
-        required: true
+  pull_request:
+    types: [opened]
 
 jobs:
   test:
@@ -27,7 +21,7 @@ jobs:
           LANGUAGE: Japanese
           MODEL: gpt-4 # https://platform.openai.com/docs/models
           # PROMPT: # example: Please check if there are any confusions or irregularities in the following code diff:
-          top_p: ${{ github.event.inputs.top_p }} # https://platform.openai.com/docs/api-reference/chat/create#chat/create-top_p
-          temperature: ${{ github.event.inputs.temperature }} # https://platform.openai.com/docs/api-reference/chat/create#chat/create-temperature
+          top_p: 1 # https://platform.openai.com/docs/api-reference/chat/create#chat/create-top_p
+          temperature: 1 # https://platform.openai.com/docs/api-reference/chat/create#chat/create-temperature
           max_tokens: 10000
           MAX_PATCH_LENGTH: 10000 # if the patch/diff length is large than MAX_PATCH_LENGTH, will be ignored and won't review. By default, with no MAX_PATCH_LENGTH set, there is also no limit for the patch/diff length.

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,2 +1,17 @@
 class Item < ApplicationRecord
+  AWERD_POINT_LIMITS = { "medicine" => 50, "food" => 100 }
+
+  def award_point
+    base_point = (price * 0.1)
+    limit = AWERD_POINT_LIMITS[category]
+    if limit&.<base_point
+      limit
+    else
+      base_point
+    end
+  end
+
+  def no_discount
+    category == "tobacco"
+  end
 end


### PR DESCRIPTION
#### ポイント付与ロジックの更新

- 医薬品カテゴリ、食料品カテゴリに関して1点ごとの付与ポイント制限を追加
- 新商品購入時のポイント倍率を変更
- 今後追加される煙草カテゴリの商品が注文に含まれていた場合、注文によるポイント付与を行わないように変更

#### キャンセル時のポイント取り消し実装

- 注文時に付与されたポイントが注文がキャンセルされても取り消されていなかったため修正
